### PR TITLE
Fix failing JodaDateTimeSqlTimestampTest

### DIFF
--- a/src/test/java/io/dropwizard/jdbi/timestamps/DatabaseInTimeZone.java
+++ b/src/test/java/io/dropwizard/jdbi/timestamps/DatabaseInTimeZone.java
@@ -28,20 +28,20 @@ public class DatabaseInTimeZone  {
         String vmArguments = "-Duser.timezone=" + timeZone.getID();
 
         ProcessBuilder pb = new ProcessBuilder(java, vmArguments, "-cp", h2jar.getAbsolutePath(), Server.class.getName(),
-                "-tcp", " -tcpShutdown", "tcp://localhost:9092", "-ifNotExists", "-baseDir", tempDir.resolve("database-in-time-zone").toString());
+                "-tcp", "-tcpPassword", "password", "-ifNotExists", "-baseDir", tempDir.resolve("database-in-time-zone").toString());
         process = pb.start();
     }
 
     protected void after() {
         try {
             // Graceful shutdown of the database
-            Server.shutdownTcpServer("tcp://localhost:9092", "", true, false);
+            Server.shutdownTcpServer("tcp://localhost:9092", "password", true, false);
             boolean exited = waitFor(process, 1, TimeUnit.SECONDS);
             if (!exited) {
                 process.destroy();
             }
         } catch (Exception e) {
-            throw new IllegalStateException("Unable shutdown DB", e);
+            throw new IllegalStateException("Unable to shutdown DB", e);
         }
     }
 

--- a/src/test/java/io/dropwizard/jdbi/timestamps/JodaDateTimeSqlTimestampTest.java
+++ b/src/test/java/io/dropwizard/jdbi/timestamps/JodaDateTimeSqlTimestampTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.skife.jdbi.v2.Handle;
@@ -26,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test for handling translation between DateTime to SQL TIMESTAMP
  * in a different time zone
  */
-@Disabled("FIXME")
 public class JodaDateTimeSqlTimestampTest {
 
     private static final DateTimeFormatter ISO_FMT = ISODateTimeFormat.dateTimeNoMillis();


### PR DESCRIPTION
Database would not spin up due to the `-tcpShutdown` parameter which is used to stop an already running instance (and it had a leading blank that H2's argument parser didn't like).

After removing the parameter, the test would run, but fail to shutdown the database, because H2 1.4.200 does not allow an empty management DB password anymore (see https://h2database.com/html/changelog.html).

Fixes #3